### PR TITLE
SonarQube Issues

### DIFF
--- a/src/main/java/com/deloitte/elrr/aggregator/consumer/ProcessPerson.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/consumer/ProcessPerson.java
@@ -31,6 +31,8 @@ public class ProcessPerson {
     @Autowired
     private PersonSvc personService;
 
+    private static final String CREATED_MESSAGE = "created";
+
     /**
      * @param statement
      * @return Person
@@ -148,7 +150,7 @@ public class ProcessPerson {
 
         personService.save(person);
 
-        log.info("Person " + person.getName() + " created.");
+        log.info("Person " + person.getName() + " " + CREATED_MESSAGE + ".");
 
         return person;
     }
@@ -193,7 +195,7 @@ public class ProcessPerson {
 
         identityService.save(identity);
 
-        log.info("Identity " + identity.getIfi() + " created.");
+        log.info("Identity " + identity.getIfi() + " " + CREATED_MESSAGE + ".");
 
         return identity;
     }
@@ -208,7 +210,7 @@ public class ProcessPerson {
         email.setEmailAddress(emailAddress);
         email.setEmailAddressType("primary");
         emailService.save(email);
-        log.info("Email " + emailAddress + " created.");
+        log.info("Email " + emailAddress + " " + CREATED_MESSAGE + ".");
         return email;
     }
 }

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompetency.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompetency.java
@@ -118,7 +118,6 @@ public class ProcessCompetency implements Rule {
             throws AggregatorException {
 
         Competency competency = null;
-        PersonalCompetency personalCompetency = null;
 
         // Get competency
         competency = competencyService.findByIdentifier(activity.getId()

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompetency.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompetency.java
@@ -99,8 +99,8 @@ public class ProcessCompetency implements Rule {
             Competency competency = processCompetency(activity);
 
             // Process PersonalCompetency
-            PersonalCompetency personalCompetency = processPersonalCompetency(
-                    activity, person, competency, extensions);
+            processPersonalCompetency(
+                    person, competency, extensions);
 
         } catch (AggregatorException e) {
             throw e;
@@ -207,14 +207,13 @@ public class ProcessCompetency implements Rule {
     }
 
     /**
-     * @param activity
      * @param person
      * @param competency
      * @param extensions
      * @return personalCompetency
      */
     private PersonalCompetency processPersonalCompetency(
-            final Activity activity, Person person, final Competency competency,
+            Person person, final Competency competency,
             final Extensions extensions) {
 
         LocalDateTime expires = null;
@@ -255,7 +254,7 @@ public class ProcessCompetency implements Rule {
             } else {
 
                 personalCompetency = updatePersonalCompetency(
-                        personalCompetency, person, competency, expires);
+                        personalCompetency, person, expires);
             }
 
         } catch (DateTimeParseException e) {
@@ -299,14 +298,13 @@ public class ProcessCompetency implements Rule {
     /**
      * @param personalCompetency
      * @param person
-     * @param competency
      * @param expires
      * @return personalCompetency
      * @throws RuntimeServiceException
      */
     public PersonalCompetency updatePersonalCompetency(
             PersonalCompetency personalCompetency, final Person person,
-            final Competency competency, final LocalDateTime expires) {
+            final LocalDateTime expires) {
 
         try {
 

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompetency.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompetency.java
@@ -41,6 +41,8 @@ public class ProcessCompetency implements Rule {
     @Autowired
     private PersonSvc personService;
 
+    private static final String COMPETENCY_MESSAGE = "Competency";
+
     /**
      * @param statement
      * @return boolean
@@ -129,7 +131,7 @@ public class ProcessCompetency implements Rule {
 
         } else {
 
-            log.info("Competency " + activity.getId() + " exists.");
+            log.info(COMPETENCY_MESSAGE + " " + activity.getId() + " exists.");
             competency = updateCompetency(competency, activity);
 
         }
@@ -162,7 +164,7 @@ public class ProcessCompetency implements Rule {
             competency.setFrameworkTitle(activityName);
             competency.setFrameworkDescription(activityDescription);
             competencyService.save(competency);
-            log.info("Competency " + activity.getId() + " created.");
+            log.info(COMPETENCY_MESSAGE + " " + activity.getId() + " created.");
 
         } catch (AggregatorException e) {
             throw e;
@@ -195,7 +197,7 @@ public class ProcessCompetency implements Rule {
             competency.setFrameworkTitle(activityName);
             competency.setFrameworkDescription(activityDescription);
             competencyService.update(competency);
-            log.info("Competency " + activity.getId() + " updated.");
+            log.info(COMPETENCY_MESSAGE + " " + activity.getId() + " updated.");
 
         } catch (AggregatorException e) {
             throw e;

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompleted.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCompleted.java
@@ -71,7 +71,7 @@ public class ProcessCompleted implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCredential.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCredential.java
@@ -100,8 +100,8 @@ public class ProcessCredential implements Rule {
             Credential credential = processCredential(activity);
 
             // Process PersonalCredential
-            PersonalCredential personalCredential = processPersonalCredential(
-                    activity, person, credential, extensions);
+            processPersonalCredential(person, credential,
+                    extensions);
 
         } catch (AggregatorException e) {
             throw e;
@@ -206,14 +206,13 @@ public class ProcessCredential implements Rule {
     }
 
     /**
-     * @param activity
      * @param person
      * @param credential
      * @param extensions
      * @return PersonalCredential
      */
     private PersonalCredential processPersonalCredential(
-            final Activity activity, Person person, final Credential credential,
+            Person person, final Credential credential,
             Extensions extensions) {
 
         LocalDateTime expires = null;
@@ -254,7 +253,7 @@ public class ProcessCredential implements Rule {
             } else {
 
                 personalCredential = updatePersonalCredential(
-                        personalCredential, person, credential, expires);
+                        personalCredential, person, expires);
             }
 
         } catch (DateTimeParseException e) {
@@ -297,14 +296,13 @@ public class ProcessCredential implements Rule {
     /**
      * @param personalCredential
      * @param person
-     * @param credential
      * @param expires
      * @return PersonalCredential
      * @throws RuntimeServiceException
      */
     public PersonalCredential updatePersonalCredential(
             PersonalCredential personalCredential, final Person person,
-            final Credential credential, final LocalDateTime expires) {
+            final LocalDateTime expires) {
 
         try {
 

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCredential.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCredential.java
@@ -119,7 +119,6 @@ public class ProcessCredential implements Rule {
             throws AggregatorException {
 
         Credential credential = null;
-        PersonalCredential personalCredential = null;
 
         // Get credential
         credential = credentialService.findByIdentifier(activity.getId()

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCredential.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessCredential.java
@@ -41,6 +41,8 @@ public class ProcessCredential implements Rule {
     @Autowired
     private PersonSvc personService;
 
+    private static final String CREDENTIAL_MESSAGE = "Credential";
+
     /**
      * @param statement
      * @return boolean
@@ -63,7 +65,8 @@ public class ProcessCredential implements Rule {
 
         // Is Verb Id = achieved and object type = competency
         return (statement.getVerb().getId().toString().equalsIgnoreCase(
-                VerbIdConstants.ACHIEVED_VERB_ID.toString()) && objType
+                VerbIdConstants.ACHIEVED_VERB_ID.toString())
+                && objType
                         .equalsIgnoreCase(ObjectTypeConstants.CREDENTIAL));
 
     }
@@ -129,7 +132,7 @@ public class ProcessCredential implements Rule {
 
         } else {
 
-            log.info("Credential " + activity.getId() + " exists.");
+            log.info(CREDENTIAL_MESSAGE + " " + activity.getId() + " exists.");
             credential = updateCredential(credential, activity);
         }
 
@@ -161,7 +164,7 @@ public class ProcessCredential implements Rule {
             credential.setFrameworkTitle(activityName);
             credential.setFrameworkDescription(activityDescription);
             credentialService.save(credential);
-            log.info("Credential " + activity.getId() + " created.");
+            log.info(CREDENTIAL_MESSAGE + " " + activity.getId() + " created.");
 
         } catch (AggregatorException e) {
             throw e;
@@ -193,7 +196,7 @@ public class ProcessCredential implements Rule {
             credential.setFrameworkTitle(activityName);
             credential.setFrameworkDescription(activityDescription);
             credentialService.update(credential);
-            log.info("Credential " + activity.getId() + " updated.");
+            log.info(CREDENTIAL_MESSAGE + " " + activity.getId() + " updated.");
 
         } catch (AggregatorException e) {
             throw e;

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessFailed.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessFailed.java
@@ -70,7 +70,7 @@ public class ProcessFailed implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessInitialized.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessInitialized.java
@@ -70,7 +70,7 @@ public class ProcessInitialized implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessPassed.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessPassed.java
@@ -70,7 +70,7 @@ public class ProcessPassed implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessRegistered.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessRegistered.java
@@ -70,7 +70,7 @@ public class ProcessRegistered implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessSatisfied.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessSatisfied.java
@@ -70,7 +70,7 @@ public class ProcessSatisfied implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessScheduled.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/rules/ProcessScheduled.java
@@ -70,7 +70,7 @@ public class ProcessScheduled implements Rule {
 
         // Process LearningRecord
         LearningRecord learningRecord = learningRecordUtil
-                .processLearningRecord(activity, person, statement.getVerb(),
+                .processLearningRecord(person, statement.getVerb(),
                         statement.getResult(), learningResource);
 
         if (person.getLearningRecords() == null) {

--- a/src/main/java/com/deloitte/elrr/aggregator/utils/LearningRecordUtil.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/utils/LearningRecordUtil.java
@@ -10,9 +10,7 @@ import com.deloitte.elrr.entity.Person;
 import com.deloitte.elrr.entity.types.LearningStatus;
 import com.deloitte.elrr.exception.RuntimeServiceException;
 import com.deloitte.elrr.jpa.svc.LearningRecordSvc;
-import com.yetanalytics.xapi.model.Activity;
 import com.yetanalytics.xapi.model.Result;
-import com.yetanalytics.xapi.model.Score;
 import com.yetanalytics.xapi.model.Verb;
 
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +23,6 @@ public class LearningRecordUtil {
     private LearningRecordSvc learningRecordService;
 
     /**
-     * @param activity
      * @param person
      * @param verb
      * @param result
@@ -33,8 +30,8 @@ public class LearningRecordUtil {
      * @return learningRccord
      * @throws RuntimeServiceException
      */
-    public LearningRecord processLearningRecord(final Activity activity,
-            final Person person, final Verb verb, final Result result,
+    public LearningRecord processLearningRecord(final Person person,
+            final Verb verb, final Result result,
             final LearningResource learningResource) {
 
         LearningRecord learningRecord = null;
@@ -88,15 +85,10 @@ public class LearningRecordUtil {
         learningRecord.setPerson(person);
         learningRecord.setRecordStatus(learningStatus);
 
-        if (result != null) {
-            Score score = result.getScore();
-            if (score != null) {
-                if (score.getScaled() != null) {
-                    learningRecord.setAcademicGrade(score.getScaled()
-                            .toString());
-                }
-            }
-
+        if (result != null && result.getScore() != null
+                && result.getScore().getScaled() != null) {
+            learningRecord.setAcademicGrade(result.getScore()
+                    .getScaled().toString());
         }
 
         learningRecordService.save(learningRecord);
@@ -127,15 +119,10 @@ public class LearningRecordUtil {
 
             learningRecord.setRecordStatus(learningStatus);
 
-            if (result != null) {
-                Score score = result.getScore();
-                if (score != null) {
-                    if (score.getScaled() != null) {
-                        learningRecord.setAcademicGrade(score.getScaled()
-                                .toString());
-                    }
-                }
-
+            if (result != null && result.getScore() != null
+                    && result.getScore().getScaled() != null) {
+                learningRecord.setAcademicGrade(result.getScore()
+                        .getScaled().toString());
             }
 
             learningRecordService.update(learningRecord);
@@ -175,7 +162,8 @@ public class LearningRecordUtil {
             return LearningStatus.ATTEMPTED;
 
         } else if (verb.getId().toString().equalsIgnoreCase(
-                VerbIdConstants.REGISTERED_VERB_ID.toString()) || verb.getId()
+                VerbIdConstants.REGISTERED_VERB_ID.toString())
+                || verb.getId()
                         .toString().equalsIgnoreCase(
                                 VerbIdConstants.SCHEDULED_VERB_ID.toString())) {
 

--- a/src/main/java/com/deloitte/elrr/elrraggregator/exception/AggregatorException.java
+++ b/src/main/java/com/deloitte/elrr/elrraggregator/exception/AggregatorException.java
@@ -9,6 +9,6 @@ public class AggregatorException extends RuntimeException {
      * @param e
      */
     public AggregatorException(String errorMessage, Exception e) {
-        super(errorMessage);
+        super(errorMessage, e);
     }
 }

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessCompetencyTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessCompetencyTest.java
@@ -143,7 +143,7 @@ class ProcessCompetencyTest {
 
             PersonalCompetency personalCompetencyResult2 = processCompetency
                     .updatePersonalCompetency(personalCompetencyResult,
-                            personResult, competencyResult, expires);
+                            personResult, expires);
             assertNotNull(personalCompetencyResult2);
             assertEquals(personalCompetencyResult2.getExpires(), expires);
 

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessCompletedTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessCompletedTest.java
@@ -100,7 +100,7 @@ class ProcessCompletedTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processCompleted.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessCredentialTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessCredentialTest.java
@@ -143,8 +143,7 @@ class ProcessCredentialTest {
                     DateTimeFormatter.ISO_DATE_TIME);
 
             PersonalCredential personalCredentialResult2 = processCredential
-                    .updatePersonalCredential(personalCredential, personResult,
-                            credentialResult, expires);
+                    .updatePersonalCredential(personalCredential, personResult, expires);
             assertNotNull(personalCredentialResult2);
             assertEquals(personalCredentialResult2.getExpires(), expires);
 

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessFailedTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessFailedTest.java
@@ -100,7 +100,7 @@ class ProcessFailedTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processFailed.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessInitializedTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessInitializedTest.java
@@ -100,7 +100,7 @@ class ProcessInitializedTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processInitialized.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessPassedTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessPassedTest.java
@@ -101,7 +101,7 @@ class ProcessPassedTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processPassed.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessRegisteredTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessRegisteredTest.java
@@ -101,7 +101,7 @@ class ProcessRegisteredTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processRegistered.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessSatisfiedTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessSatisfiedTest.java
@@ -101,7 +101,7 @@ class ProcessSatisfiedTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processSatisfied.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessScheduledTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/rules/ProcessScheduledTest.java
@@ -101,7 +101,7 @@ class ProcessScheduledTest {
             learningRecord.setPerson(person);
             learningRecord.setLearningResource(learningResource);
             Mockito.doReturn(learningRecord).when(learningRecordUtil)
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
 
             boolean fireRule = processScheduled.fireRule(stmt);

--- a/src/test/java/com/deloitte/elrr/aggregator/util/LearningRecordUtilTest.java
+++ b/src/test/java/com/deloitte/elrr/aggregator/util/LearningRecordUtilTest.java
@@ -71,7 +71,7 @@ class LearningRecordUtilTest {
             learningResource.setDescription("Example Activity Test");
 
             LearningRecord learningRecord = learningRecordUtil
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
             assertNotNull(learningRecord);
             assertNotNull(learningRecord.getPerson());
@@ -160,7 +160,7 @@ class LearningRecordUtilTest {
                     "A fictitious example CBT 2 course.");
 
             LearningRecord learningRecord = learningRecordUtil
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
             assertNotNull(learningRecord);
             assertNotNull(learningRecord.getPerson());
@@ -206,7 +206,7 @@ class LearningRecordUtilTest {
             learningResource.setDescription("A fictitious example CBT course.");
 
             LearningRecord learningRecord = learningRecordUtil
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
             assertNotNull(learningRecord);
             assertNotNull(learningRecord.getPerson());
@@ -252,7 +252,7 @@ class LearningRecordUtilTest {
             learningResource.setDescription("Example activity 10 description");
 
             LearningRecord learningRecord = learningRecordUtil
-                    .processLearningRecord(activity, person, verb, result,
+                    .processLearningRecord(person, verb, result,
                             learningResource);
             assertNotNull(learningRecord);
             assertNotNull(learningRecord.getPerson());


### PR DESCRIPTION
Defined a constant instead of duplicating string.
Removed useless assignment, unused method parameters along with their unit tests.
Merged unnecessary nested if statements.

**### Summary of Changes (13 SonarQube issues)**
1. String Literal Duplication (java:S1192)
    - Defined constants for the following repeated string literals and replaced all occurrences of these literal with their constant:
      - " created" in ProcessPerson.java
      - "Competency " in ProcessCompetency.java
      - "Credential " in ProcessCredential.java

2. Unused Assignments (java:S1854)
    - Removed useless assignments to local variables:
      - personalCompetency in ProcessCompetency.java
      - personalCredential in ProcessCredential.java

3. Unused Method Parameters (java:S1172)
    - Removed/using unused method parameters:
      - activity in ProcessCompetency.java (L215)
      - competency in ProcessCompetency.java (L307)
      - activity in ProcessCredential.java (L213)
      - credential in ProcessCredential.java (L304)
      - activity in LearningRecordUtil.java (L36)
      - e in AggregatorException.java (L11)

4. Merge If Statements (java:S1066)
    - Combined nested if statements into single statements:
      - At L94 and L133 in LearningRecordUtil.java





