### PR TITLE
SonarQube and Dependency-Check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
 			<version>10.1.42</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.tomcat.embed</groupId>
+			<artifactId>tomcat-embed-websocket</artifactId>
+			<version>10.1.42</version>
+		</dependency>
+		<dependency>
 			<groupId>fr.spacefox</groupId>
 			<artifactId>confusable-homoglyphs</artifactId>
 			<version>1.1.1</version>

--- a/src/main/java/com/deloitte/elrr/aggregator/utils/LangMapUtil.java
+++ b/src/main/java/com/deloitte/elrr/aggregator/utils/LangMapUtil.java
@@ -52,7 +52,7 @@ public class LangMapUtil {
      */
     public LangTag getCodeWithPrefix(Set<LangTag> tags, String prefix) {
         for (LangTag tag : new ArrayList<LangTag>(tags)) {
-            if (tag.toString().startsWith("en")) {
+            if (tag.toString().startsWith(prefix)) {
                 return tag;
             }
         }


### PR DESCRIPTION
Added and Upgraded tomcat-embed-websocket to version 10.1.42 since the version that comes with Spring Boot (10.1.40) was flagged by dependency-check for two vulnerabilities (CVE-2025-46701 and CVE-2025-48988).
Cleaned up an unused method parameter (prefix) to fix a SonarQube issue.